### PR TITLE
Colour band purple and remove glove glyph

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,6 +67,7 @@ lastmod = ["lastmod", ":git", "date"]
     danger = "#FFA326"
     light = "#FDFCF9"
     dark = "#B12629"
+    rumble = "#4458BE"
 
 # main/prepend/postpend menus are displayed in nav fragment.
 # Keep an eye out for updates. These will be moved out to make navbar more

--- a/content/_index/reading-rumble-2024.md
+++ b/content/_index/reading-rumble-2024.md
@@ -3,7 +3,7 @@ fragment = "item"
 #disabled = false
 
 weight = 114
-background = "dark"
+background = "rumble"
 align = "right"
 minHeight = "40vh"
 

--- a/layouts/partials/fragments/prln-nav.html
+++ b/layouts/partials/fragments/prln-nav.html
@@ -172,7 +172,7 @@
             
                    <li>
 			<details class="prlnDD" id="tRDetails">
-				<summary><a href="{{ "about/events-and-awards/#reading-rumble-events" | relLangURL }}">Reading Rumble &#129354;</a></summary>
+				<summary><a href="{{ "about/events-and-awards/#reading-rumble-events" | relLangURL }}">Reading Rumble</a></summary>
 				
 			</details>
 		</li>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -463,7 +463,9 @@ tr.facts td {
     color: #0E83CD;
 }
 
-
+.bg-rumble {
+    background-color: #4458BE !important;
+}
 
 .bg-warning a.white-bg-hover:hover, .bg-info a.white-bg-hover:hover, .bg-secondary a.white-bg-hover:hover, .bg-danger a.white-bg-hover:hover {
     display: block;
@@ -1394,11 +1396,11 @@ h2 a:hover {
     text-shadow: 2px 2px 4px black;
 }
 
-.bg-dark .text-white p a {
+.bg-rumble .text-white p a {
     color: white !important;
 }
 
-.bg-dark .text-white p a:hover {
+.bg-rumble .text-white p a:hover {
     color: white !important;
     filter: brightness(1);
     text-shadow: 2px 2px 4px black;

--- a/themes/syna/layouts/partials/helpers/text-color.html
+++ b/themes/syna/layouts/partials/helpers/text-color.html
@@ -1,7 +1,7 @@
 {{- $bg := .self.Scratch.Get "bg" }}
 {{- $text_black := cond (isset . "dark") (cond (eq .dark "") "" (printf "text-%s" .dark)) "text-body" -}}
 {{- $text_white := cond (isset . "light") (cond (eq .light "") "" (printf "text-%s" .light)) "text-white" -}}
-{{- if in (slice "primary" "dark" ) $bg -}}
+{{- if in (slice "primary" "dark" "rumble" ) $bg -}}
   {{- printf " %s" $text_white -}}
 {{- else -}}
   {{- printf " %s" $text_black -}}


### PR DESCRIPTION
Remove the little glove from the ribbon, and change the red band to be purple on the home page.  We use purple #4458BE on most of our marketing materials.